### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/support": "~5.3|~5.4|~5.5",
+        "illuminate/support": "5.3.*|5.4.*|5.5.*",
         "guzzlehttp/guzzle": "~6.0"
     },
     "autoload": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `~5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.